### PR TITLE
Do not limit requests version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ packages = [
 ]
 
 requires = [
-    'requests>=1.0.0,<2.3.0',
+    'requests>=1.0.0,<3.0',
     'pycountry',
 ]
 


### PR DESCRIPTION
Is there any reason to restrict the upper bound of requests' version ?

PyVAT seems to work just fine with newer releases.
