### PR TITLE
Fix compatibility with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
-install: "pip install -r dev-requirements.txt --use-mirrors"
+  - "3.5"
+install:
+    - pip install .
+    - pip install -r dev-requirements.txt
 script: make test

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,3 @@ pycountry
 sphinx
 sphinx_rtd_theme
 unittest2
-enum34

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
+import sys
 
 
 packages = [
@@ -12,8 +13,11 @@ packages = [
 requires = [
     'requests>=1.0.0,<3.0',
     'pycountry',
-    'enum34',
 ]
+# Incompatible with Py 3.5+: https://bitbucket.org/stoneleaf/enum34/issues/5
+if (sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 5):
+    requires.append('enum34')
 
 tests_require = [
     'nose',
@@ -47,5 +51,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ),
 )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -130,7 +130,7 @@ VAT_NUMBER_CHECK_CASES = {
              True,
              business_name=u'NV UNILEVER BELGIUM - UNILEVER BELGIQUE - '
              u'UNILEVER BELGIE',
-             business_address=u'HUMANITEITSLAAN 292\n1190  VORST'
+             business_address=u'HUMANITEITSLAAN 292\n1190 VORST'
          )),
     ],
     'DK': [


### PR DESCRIPTION
The enum34 package must not be installed on Python 3.5+, for more info see https://bitbucket.org/stoneleaf/enum34/issues/5

Also fix an issue with the unit tests, apparently the amount of whitespace in one of the tests has changed.
