### PR TITLE
Fix compatibility with new pycountry version

### DIFF
--- a/pyvat/__init__.py
+++ b/pyvat/__init__.py
@@ -127,7 +127,7 @@ def decompose_vat_number(vat_number, country_code=None):
 
         if country_code not in VAT_REGISTRIES:
             try:
-                if not pycountry.countries.get(alpha2=country_code):
+                if not pycountry.countries.get(alpha_2=country_code):
                     return (None, None)
             except KeyError:
                 return (None, None)

--- a/tests/test_sale_vat_charge.py
+++ b/tests/test_sale_vat_charge.py
@@ -361,7 +361,7 @@ class GetSaleVatChargeTestCase(TestCase):
         # EU businesses selling to customers outside the EU do not charge VAT.
         for seller_cc in EU_COUNTRY_CODES:
             for buyer_country in pycountry.countries:
-                buyer_cc = buyer_country.alpha2
+                buyer_cc = buyer_country.alpha_2
                 if buyer_cc in EU_COUNTRY_CODES:
                     continue
 


### PR DESCRIPTION
Ok this now passes on 2.7, 3.3 and 3.4. 2.6 fails because of flake8 is no longer supporting 2.6. I think we should really consider dropping support for 2.6, and maybe start looking at python 3.5. That would require a new breaking release.
