### PR TITLE
Do not install enum34 on python >= 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ packages = [
 requires = [
     'requests>=1.0.0,<3.0',
     'pycountry',
-    'enum34',
+    'enum34; python_version < "3.4"',
 ]
 
 tests_require = [


### PR DESCRIPTION
Similar to https://github.com/iconfinder/pyvat/pull/10 and https://github.com/iconfinder/pyvat/pull/6.