### PR TITLE
Remove python3 parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-with open("README.rst", "r", encoding="utf-8") as fh:
+with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 packages = [


### PR DESCRIPTION
`enconding` parameter in the `open()` function prevented the package from being loaded in Python2.
It has been removed now. 