### PR TITLE
[fix] Change Ireland's VAT rate back to 23% (COVID cut is over)

### DIFF
--- a/pyvat/vat_rules.py
+++ b/pyvat/vat_rules.py
@@ -360,7 +360,7 @@ VAT_RULES = {
     'FR': FrVatRules(),
     'HR': HrVatRules(25),
     'HU': ConstantEuVatRateRules(27),
-    'IE': IeVatRules(21),
+    'IE': IeVatRules(23),
     'IT': ConstantEuVatRateRules(22),
     'LT': ConstantEuVatRateRules(21),
     'LU': LuVatRules(),


### PR DESCRIPTION
Ireland has announced a temporary VAT rate cut from 23% to 21%. The
measure will come into place on 1 September 2020 until 28 February 2021.