### PR TITLE
Added business_country_code to VatNumberCheckResult

### DIFF
--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -179,6 +179,16 @@ class ViesRegistry(Registry):
             result.business_address = get_text(address_node).strip() or None
         except Exception:
             pass
+        
+        # Parse the country code if possible.
+        try:
+            country_code_node = get_first_child_element(
+                check_vat_response_node,
+                'ns2:countryCode'
+            )
+            result.business_country_code = get_text(country_code_node).strip() or None
+        except Exception:
+            pass
 
         return result
 

--- a/pyvat/result.py
+++ b/pyvat/result.py
@@ -15,8 +15,10 @@ class VatNumberCheckResult(object):
                  is_valid=None,
                  log_lines=None,
                  business_name=None,
-                 business_address=None):
+                 business_address=None,
+                 business_country_code=None):
         self.is_valid = is_valid
         self.log_lines = log_lines or []
         self.business_name = business_name
         self.business_address = business_address
+        self.business_country_code = business_country_code


### PR DESCRIPTION
When using pyvat to validate a VAT number from user input, the response does not include the country code, making it difficult to know which country the returned address is for.
This adds a new attribute` business_country_code` to `VatNumberCheckResult` with the returned country code from the response.