### PR TITLE
Update Finland VAT from 24% to 25.5%

### DIFF
--- a/pyvat/vat_rules.py
+++ b/pyvat/vat_rules.py
@@ -356,7 +356,7 @@ VAT_RULES = {
     'EL': ElVatRules(),
     'GR': ElVatRules(),  # Synonymous country code for Greece
     'ES': EsVatRules(),
-    'FI': FiVatRules(24),
+    'FI': FiVatRules(25.5),
     'FR': FrVatRules(),
     'HR': HrVatRules(25),
     'HU': ConstantEuVatRateRules(27),


### PR DESCRIPTION
Finland changed VAT to 25.5% on September 1st, 2025: https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/