### PR TITLE
Seller specific vat check with verification identifier in response

### DIFF
--- a/pyvat/__init__.py
+++ b/pyvat/__init__.py
@@ -214,6 +214,55 @@ def check_vat_number(vat_number, country_code=None, test=False):
     return VAT_REGISTRIES[country_code].check_vat_number(vat_number,
                                                          country_code, test)
 
+def check_vat_number_with_request_identifier(vat_number, requester_country_code, requester_vat_number, country_code=None):
+    """
+    Check if a VAT number is valid using a registry that supports request identification.
+
+    This function validates the given VAT number, taking into account the requester's information (requester_country_code and requester_vat_number)
+    as required by certain national authorities for proper auditing and evidence. When called, the function will attempt to verify the VAT number
+    and will return a VatNumberCheckResult instance containing the result of the validation. The result object also contains a 'verificationIdentifier'
+    (request_identifier), which serves as a unique proof of the verification that can be stored and presented to authorities should a selling company
+    undergo an audit.
+
+    :param vat_number: VAT number to validate.
+    :param requester_country_code: Country code of the requesting party (e.g., your own company).
+    :param requester_vat_number: VAT number of the requesting party (e.g., your own company VAT number).
+    :param country_code:
+        Optional country code. Should be supplied if known, as there is no
+        guarantee that naively entered VAT numbers contain the correct alpha-2
+        country code prefix for EU countries just as not all non-EU countries
+        have a reliable country code prefix. Default ``None`` prompting
+        detection.
+    :returns:
+        a :class:`VatNumberCheckResult` instance containing the result for the
+        full VAT number check. The result includes a 'verificationIdentifier' that can be retained
+        for compliance and audit purposes with relevant authorities.
+    """
+
+    # Decompose the VAT number.
+    vat_number, country_code = decompose_vat_number(vat_number, country_code)
+    if not vat_number or not country_code:
+        return VatNumberCheckResult(False, [
+            '> Unable to decompose VAT number, resulted in %r and %r' %
+            (vat_number, country_code)
+        ])
+
+    # Test the VAT number format.
+    format_result = is_vat_number_format_valid(vat_number, country_code)
+    if format_result is not True:
+        return VatNumberCheckResult(format_result, [
+            '> VAT number validation failed: %r' % (format_result)
+        ])
+
+    # Attempt to check the VAT number against a registry.
+    if country_code not in VAT_REGISTRIES:
+        return VatNumberCheckResult()
+
+    return VAT_REGISTRIES[country_code].check_vat_number_with_request_identifier(vat_number,
+                                                        requester_country_code,
+                                                        requester_vat_number,
+                                                        country_code
+                                                        )
 
 def get_sale_vat_charge(date,
                         item_type,

--- a/pyvat/__init__.py
+++ b/pyvat/__init__.py
@@ -220,7 +220,7 @@ def check_vat_number_with_request_identifier(vat_number, requester_country_code,
 
     This function validates the given VAT number, taking into account the requester's information (requester_country_code and requester_vat_number)
     as required by certain national authorities for proper auditing and evidence. When called, the function will attempt to verify the VAT number
-    and will return a VatNumberCheckResult instance containing the result of the validation. The result object also contains a 'verificationIdentifier'
+    and will return a VatNumberCheckResult instance containing the result of the validation. The result object also contains a 'request_identifier'
     (request_identifier), which serves as a unique proof of the verification that can be stored and presented to authorities should a selling company
     undergo an audit.
 
@@ -235,7 +235,7 @@ def check_vat_number_with_request_identifier(vat_number, requester_country_code,
         detection.
     :returns:
         a :class:`VatNumberCheckResult` instance containing the result for the
-        full VAT number check. The result includes a 'verificationIdentifier' that can be retained
+        full VAT number check. The result includes a 'request_identifier' that can be retained
         for compliance and audit purposes with relevant authorities.
     """
 

--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -52,8 +52,6 @@ class ViesRegistry(Registry):
         def _tag(name, val):
             # Omit empty optionals; VIES accepts missing optionals
             return f'<ns0:{name}>{val}</ns0:{name}>' if val not in (None, "") else ''
-        requester_country_code = 'DK'
-        requester_vat_number = '43083341'
         request_data = (
             u'<?xml version="1.0" encoding="UTF-8"?>'
             u'<SOAP-ENV:Envelope '

--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -6,6 +6,7 @@ from requests import Timeout
 from .result import VatNumberCheckResult
 from .xml_utils import get_first_child_element, get_text, NodeNotFoundError
 from .exceptions import ServerError
+from .utils import first_child_by_localname
 
 
 class Registry(object):
@@ -36,10 +37,175 @@ class ViesRegistry(Registry):
                             'services/checkVatService'
     """URL for the VAT checking service.
     """
+    
 
     DEFAULT_TIMEOUT = 8
     """Timeout for the requests."""
 
+    def check_vat_number_with_request_identifier(self, vat_number, requester_country_code, requester_vat_number, country_code) :
+        if country_code == 'GR':
+            country_code = 'EL'
+
+        result = VatNumberCheckResult()
+
+        # --- build SOAP for checkVatApprox (not checkVat) ---
+        def _tag(name, val):
+            # Omit empty optionals; VIES accepts missing optionals
+            return f'<ns0:{name}>{val}</ns0:{name}>' if val not in (None, "") else ''
+        requester_country_code = 'DK'
+        requester_vat_number = '43083341'
+        request_data = (
+            u'<?xml version="1.0" encoding="UTF-8"?>'
+            u'<SOAP-ENV:Envelope '
+            u'xmlns:ns0="urn:ec.europa.eu:taxud:vies:services:checkVat:types" '
+            u'xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/" '
+            u'xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">'
+            u'<SOAP-ENV:Header/>'
+            u'<ns1:Body>'
+            u'  <ns0:checkVatApprox>'
+            u'    <ns0:countryCode>%s</ns0:countryCode>'
+            u'    <ns0:vatNumber>%s</ns0:vatNumber>'
+            # all of these are optional; leave out unless you want to use them
+            f'    {_tag("traderName", None)}'
+            f'    {_tag("traderCompanyType", None)}'
+            f'    {_tag("traderStreet", None)}'
+            f'    {_tag("traderPostcode", None)}'
+            f'    {_tag("traderCity", None)}'
+            f'    {_tag("requesterCountryCode", requester_country_code)}'
+            f'    {_tag("requesterVatNumber", requester_vat_number)}'
+            u'  </ns0:checkVatApprox>'
+            u'</ns1:Body>'
+            u'</SOAP-ENV:Envelope>'
+        ) % (country_code, vat_number)
+
+        result.log_lines += [
+            u'> POST %s with payload of content type text/xml, charset UTF-8:',
+            request_data,
+        ]
+
+        try:
+            response = requests.post(
+                self.CHECK_VAT_SERVICE_URL,
+                data=request_data.encode('utf-8'),
+                headers={'Content-Type': 'text/xml; charset=utf-8'},
+                timeout=self.DEFAULT_TIMEOUT
+            )
+            # REMOVE: response.request_identifier (not a requests attr)
+        except Timeout as e:
+            result.log_lines.append(u'< Request to EU VIES registry timed out: {}'.format(e))
+            return result
+        except Exception as exception:
+            result.log_lines.append(u'< Request failed with exception: %r' % (exception))
+            return result
+
+        content_type = response.headers.get('Content-Type', '')
+        result.log_lines += [
+            u'< Response with status %d of content type %s:' %
+            (response.status_code, content_type),
+            response.text,
+        ]
+
+        if response.status_code != 200 or not content_type.startswith('text/xml'):
+            result.log_lines.append(u'< Response is nondeterministic due to invalid response status code or MIME type')
+            return result
+
+        # ---- Robust XML parsing (ignore prefixes) ----
+        dom = xml.dom.minidom.parseString(response.text)
+
+        envelope_node = dom.documentElement
+        # Don’t assert exact prefix; just ensure it’s an Envelope
+        env_local = getattr(envelope_node, "localName", None) or envelope_node.tagName
+        if not (env_local == "Envelope" or env_local.endswith(":Envelope")):
+            raise ValueError('expected response XML root element to be a SOAP envelope')
+
+        body_node = None
+        try:
+            # Try your original util first
+            body_node = get_first_child_element(envelope_node, 'env:Body')
+        except Exception:
+            # Fallback: prefix-agnostic
+            body_node = first_child_by_localname(envelope_node, 'Body')
+
+        # Fault handling (prefix-agnostic)
+        try:
+            # Try original
+            error_node = get_first_child_element(body_node, 'env:Fault')
+            fault_strings = error_node.getElementsByTagName('faultstring')
+            fault_code = fault_strings[0].firstChild.nodeValue
+            raise ServerError(fault_code)
+        except NodeNotFoundError:
+            # Also check by localName just in case
+            try:
+                fault_node = first_child_by_localname(body_node, 'Fault')
+                fault_strings = fault_node.getElementsByTagName('faultstring')
+                fault_code = fault_strings[0].firstChild.nodeValue
+                raise ServerError(fault_code)
+            except Exception:
+                pass
+        # response node: checkVatApproxResponse (not checkVatResponse)
+        try:
+            check_vat_response_node = get_first_child_element(body_node, 'ns2:checkVatApproxResponse')
+        except Exception:
+            check_vat_response_node = next(
+                c for c in body_node.childNodes
+                if getattr(c, "localName", "") == "checkVatApproxResponse"
+            )
+
+        # valid
+        try:
+            valid_node = get_first_child_element(check_vat_response_node, 'ns2:valid')
+        except Exception:
+            valid_node = first_child_by_localname(check_vat_response_node, 'valid')
+
+        valid_text = get_text(valid_node)
+        if valid_text in ('true', 'false'):
+            result.is_valid = (valid_text == 'true')
+        else:
+            result.log_lines.append(u'< Response is nondeterministic due to invalid validity field: %r' % (valid_text))
+
+        # traderName -> business_name
+        try:
+            try:
+                name_node = get_first_child_element(check_vat_response_node, 'ns2:traderName')
+            except Exception:
+                name_node = first_child_by_localname(check_vat_response_node, 'traderName')
+            result.business_name = (get_text(name_node) or '').strip() or None
+        except Exception:
+            pass
+
+        # traderAddress -> business_address
+        try:
+            try:
+                address_node = get_first_child_element(check_vat_response_node, 'ns2:traderAddress')
+            except Exception:
+                address_node = first_child_by_localname(check_vat_response_node, 'traderAddress')
+            result.business_address = (get_text(address_node) or '').strip() or None
+        except Exception:
+            pass
+
+        # countryCode
+        try:
+            try:
+                cc_node = get_first_child_element(check_vat_response_node, 'ns2:countryCode')
+            except Exception:
+                cc_node = first_child_by_localname(check_vat_response_node, 'countryCode')
+            result.business_country_code = (get_text(cc_node) or '').strip() or None
+        except Exception:
+            pass
+
+        # requestIdentifier  ✅ (use the correct node variable)
+        try:
+            try:
+                ri_node = get_first_child_element(check_vat_response_node, 'ns2:requestIdentifier')
+            except Exception:
+                ri_node = first_child_by_localname(check_vat_response_node, 'requestIdentifier')
+            result.request_identifier = (get_text(ri_node) or '').strip() or None
+        except Exception:
+            result.request_identifier = None
+
+        result.log_lines.append(u'< Parsed requestIdentifier: %r' % (result.request_identifier,))
+        return result
+    
     def check_vat_number(self, vat_number, country_code, test):
         # Non-ISO code used for Greece.
         if country_code == 'GR':

--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -79,7 +79,7 @@ class ViesRegistry(Registry):
         ) % (country_code, vat_number)
 
         result.log_lines += [
-            u'> POST %s with payload of content type text/xml, charset UTF-8:',
+            u'> POST %s with payload of content type text/xml, charset UTF-8:' % self.CHECK_VAT_SERVICE_URL,
             request_data,
         ]
 

--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import xml.dom.minidom
 
@@ -26,7 +27,6 @@ class Registry(object):
 
         raise NotImplementedError()
 
-
 class ViesRegistry(Registry):
     """VIES registry.
 
@@ -37,21 +37,24 @@ class ViesRegistry(Registry):
                             'services/checkVatService'
     """URL for the VAT checking service.
     """
-    
 
     DEFAULT_TIMEOUT = 8
     """Timeout for the requests."""
 
-    def check_vat_number_with_request_identifier(self, vat_number, requester_country_code, requester_vat_number, country_code) :
+    def check_vat_number_with_request_identifier(self, vat_number, requester_country_code, requester_vat_number, country_code):
+        """
+        Checks VAT number via checkVatApprox, complies with privacy logging (GDPR).
+        """
         if country_code == 'GR':
             country_code = 'EL'
 
         result = VatNumberCheckResult()
 
-        # --- build SOAP for checkVatApprox (not checkVat) ---
+        # --- build SOAP for checkVatApprox ---
         def _tag(name, val):
             # Omit empty optionals; VIES accepts missing optionals
             return f'<ns0:{name}>{val}</ns0:{name}>' if val not in (None, "") else ''
+
         request_data = (
             u'<?xml version="1.0" encoding="UTF-8"?>'
             u'<SOAP-ENV:Envelope '
@@ -76,10 +79,18 @@ class ViesRegistry(Registry):
             u'</SOAP-ENV:Envelope>'
         ) % (country_code, vat_number)
 
-        result.log_lines += [
-            u'> POST %s with payload of content type text/xml, charset UTF-8:' % self.CHECK_VAT_SERVICE_URL,
-            request_data,
-        ]
+        # GDPR/PII-aware logging
+        DEBUG_VAT_LOGS = os.environ.get("DEBUG_VAT_LOGS", "0") == "1"
+        if DEBUG_VAT_LOGS:
+            # Redact PII in logs
+            redacted_request = request_data
+            redacted_request = redacted_request.replace(vat_number, "[REDACTED-VAT]")
+            if requester_vat_number:
+                redacted_request = redacted_request.replace(requester_vat_number, "[REDACTED-REQUESTER]")
+            result.log_lines.append(u'> POST %s with payload of content type text/xml, charset UTF-8 (REDACTED).' % (self.CHECK_VAT_SERVICE_URL,))
+            result.log_lines.append(redacted_request)
+        else:
+            result.log_lines.append(u'> VIES checkVatApprox API call issued (request payload redacted for privacy)')
 
         try:
             response = requests.post(
@@ -97,11 +108,24 @@ class ViesRegistry(Registry):
             return result
 
         content_type = response.headers.get('Content-Type', '')
-        result.log_lines += [
-            u'< Response with status %d of content type %s:' %
-            (response.status_code, content_type),
-            response.text,
-        ]
+
+        # Only log full response status if debug, else only status, not body
+        if DEBUG_VAT_LOGS:
+            log_response_text = response.text
+            # Redact PII (replace VAT numbers, request identifiers)
+            log_response_text = log_response_text.replace(vat_number, "[REDACTED-VAT]")
+            if requester_vat_number:
+                log_response_text = log_response_text.replace(requester_vat_number, "[REDACTED-REQUESTER]")
+            result.log_lines.append(
+                u'< Response with status %d of content type %s (REDACTED):' %
+                (response.status_code, content_type)
+            )
+            result.log_lines.append(log_response_text)
+        else:
+            result.log_lines.append(
+                u'< VIES response status: %d, content-type: %s (response content redacted for privacy)' %
+                (response.status_code, content_type)
+            )
 
         if response.status_code != 200 or not content_type.startswith('text/xml'):
             result.log_lines.append(u'< Response is nondeterministic due to invalid response status code or MIME type')
@@ -111,28 +135,23 @@ class ViesRegistry(Registry):
         dom = xml.dom.minidom.parseString(response.text)
 
         envelope_node = dom.documentElement
-        # Don’t assert exact prefix; just ensure it’s an Envelope
         env_local = getattr(envelope_node, "localName", None) or envelope_node.tagName
         if not (env_local == "Envelope" or env_local.endswith(":Envelope")):
             raise ValueError('expected response XML root element to be a SOAP envelope')
 
         body_node = None
         try:
-            # Try your original util first
             body_node = get_first_child_element(envelope_node, 'env:Body')
         except Exception:
-            # Fallback: prefix-agnostic
             body_node = first_child_by_localname(envelope_node, 'Body')
 
         # Fault handling (prefix-agnostic)
         try:
-            # Try original
             error_node = get_first_child_element(body_node, 'env:Fault')
             fault_strings = error_node.getElementsByTagName('faultstring')
             fault_code = fault_strings[0].firstChild.nodeValue
             raise ServerError(fault_code)
         except NodeNotFoundError:
-            # Also check by localName just in case
             try:
                 fault_node = first_child_by_localname(body_node, 'Fault')
                 fault_strings = fault_node.getElementsByTagName('faultstring')
@@ -140,7 +159,7 @@ class ViesRegistry(Registry):
                 raise ServerError(fault_code)
             except Exception:
                 pass
-        # response node: checkVatApproxResponse (not checkVatResponse)
+
         try:
             check_vat_response_node = get_first_child_element(body_node, 'ns2:checkVatApproxResponse')
         except Exception:
@@ -191,7 +210,7 @@ class ViesRegistry(Registry):
         except Exception:
             pass
 
-        # requestIdentifier  ✅ (use the correct node variable)
+        # requestIdentifier
         try:
             try:
                 ri_node = get_first_child_element(check_vat_response_node, 'ns2:requestIdentifier')
@@ -201,7 +220,19 @@ class ViesRegistry(Registry):
         except Exception:
             result.request_identifier = None
 
-        result.log_lines.append(u'< Parsed requestIdentifier: %r' % (result.request_identifier,))
+        # Essential summary log (NO PII or full objects)
+        summary = (
+            u'< VIES checkVatApprox result: '
+            u'validity=%r, '
+            u'status_code=%s, '
+            u'requestIdentifier=%r'
+        ) % (
+            result.is_valid,
+            response.status_code,
+            result.request_identifier
+        )
+        result.log_lines.append(summary)
+
         return result
     
     def check_vat_number(self, vat_number, country_code, test):

--- a/pyvat/result.py
+++ b/pyvat/result.py
@@ -9,6 +9,9 @@ class VatNumberCheckResult(object):
         Check log lines.
     :ivar business_name: Optional business name retrieved for the VAT number.
     :ivar business_address: Optional address retrieved for the VAT number.
+    :ivar business_country_code: Optional country code for the business (if available).
+    :ivar request_identifier:
+        Optional unique identifier for the request, as returned by the registry (for example, provided in VIES checkVatApprox responses as the requestIdentifier node)—useful for audit, support, or evidence of inquiry.
     """
 
     def __init__(self,
@@ -16,9 +19,11 @@ class VatNumberCheckResult(object):
                  log_lines=None,
                  business_name=None,
                  business_address=None,
-                 business_country_code=None):
+                 business_country_code=None,
+                 request_identifier=None):
         self.is_valid = is_valid
         self.log_lines = log_lines or []
         self.business_name = business_name
         self.business_address = business_address
         self.business_country_code = business_country_code
+        self.request_identifier = request_identifier  # The requestIdentifier from the registry response, if present

--- a/pyvat/utils.py
+++ b/pyvat/utils.py
@@ -1,5 +1,18 @@
 from decimal import Decimal
-
+from .xml_utils import NodeNotFoundError
 
 def ensure_decimal(value):
     return value if isinstance(value, Decimal) else Decimal(value)
+
+
+def first_child_by_localname(node, localname):
+        """Return the first child element whose localName matches, ignoring prefixes."""
+        for child in getattr(node, "childNodes", []):
+            if child.nodeType == child.ELEMENT_NODE:
+                # localName is None for non-namespaced elements; fall back to tagName
+                ln = getattr(child, "localName", None) or child.tagName
+                # handle both "requestIdentifier" and "ns2:requestIdentifier"
+                if ln == localname or ln.endswith(":" + localname):
+                    return child
+        raise NodeNotFoundError(f"Child with local name '{localname}' not found")
+        

--- a/pyvat/utils.py
+++ b/pyvat/utils.py
@@ -6,12 +6,13 @@ def ensure_decimal(value):
 
 
 def first_child_by_localname(node, localname):
-        """Return the first child element whose localName matches, ignoring prefixes."""
-        for child in getattr(node, "childNodes", []):
-            if child.nodeType == child.ELEMENT_NODE:
-                # localName is None for non-namespaced elements; fall back to tagName
-                ln = getattr(child, "localName", None) or child.tagName
-                # handle both "requestIdentifier" and "ns2:requestIdentifier"
-                if ln == localname or ln.endswith(":" + localname):
-                    return child
-        raise NodeNotFoundError(f"Child with local name '{localname}' not found")
+    """Return the first child element whose localName matches, ignoring prefixes."""
+    for child in getattr(node, "childNodes", []):
+        if child.nodeType == child.ELEMENT_NODE:
+            # localName is None for non-namespaced elements; fall back to tagName
+            ln = getattr(child, "localName", None) or child.tagName
+            # handle both "requestIdentifier" and "ns2:requestIdentifier"
+            if ln == localname or ln.endswith(":" + localname):
+                return child
+    raise NodeNotFoundError(f"Child with local name '{localname}' not found")
+        

--- a/pyvat/utils.py
+++ b/pyvat/utils.py
@@ -15,4 +15,3 @@ def first_child_by_localname(node, localname):
                 if ln == localname or ln.endswith(":" + localname):
                     return child
         raise NodeNotFoundError(f"Child with local name '{localname}' not found")
-        


### PR DESCRIPTION
<h2 data-start="366" data-end="436">✨ feat(vies): expose VIES <code data-start="395" data-end="414">requestIdentifier</code> (consultation number)</h2>
<blockquote data-start="438" data-end="674">
<p data-start="440" data-end="447"><strong data-start="440" data-end="447">Why</strong></p>
<p data-start="452" data-end="674">Audits/ERPs often require storing the official VIES consultation number for each VAT check. The legacy <code data-start="555" data-end="565">checkVat</code> API does <strong data-start="575" data-end="582">not</strong> return it; <code data-start="594" data-end="613">requestIdentifier</code> is provided by <strong data-start="629" data-end="649"><code data-start="631" data-end="647">checkVatApprox</code></strong> (SOAP) and the REST API.</p>
</blockquote>
<h3 data-start="676" data-end="694">✅ What changed</h3>
<ul data-start="695" data-end="1181">
<li data-start="695" data-end="758">
<p data-start="697" data-end="758"><strong data-start="697" data-end="711">New field:</strong> <code data-start="712" data-end="732">request_identifier</code> in <code data-start="736" data-end="758">VatNumberCheckResult</code></p>
</li>
<li data-start="759" data-end="869">
<p data-start="761" data-end="869"><strong data-start="761" data-end="774">New path:</strong> <code data-start="775" data-end="791">checkVatApprox</code> flow that returns <code data-start="810" data-end="829">requestIdentifier</code> when <strong data-start="835" data-end="848">requester</strong> details are provided</p>
</li>
<li data-start="870" data-end="954">
<p data-start="872" data-end="954"><strong data-start="872" data-end="900">Prefix-agnostic parsing:</strong> robust XML by <strong data-start="915" data-end="928">localName</strong> (ignores <code data-start="938" data-end="944">nsX:</code> prefixes)</p>
</li>
<li data-start="955" data-end="1044">
<p data-start="957" data-end="1044"><strong data-start="957" data-end="975">Field mapping:</strong> <code data-start="976" data-end="988">traderName</code> → <code data-start="991" data-end="1006">business_name</code>, <code data-start="1008" data-end="1023">traderAddress</code> → <code data-start="1026" data-end="1044">business_address</code></p>
</li>
<li data-start="1045" data-end="1094">
<p data-start="1047" data-end="1094"><strong data-start="1047" data-end="1066">HTTPS endpoint:</strong> ensured SOAP URL uses HTTPS</p>
</li>
<li data-start="1095" data-end="1181">
<p data-start="1097" data-end="1181"><strong data-start="1097" data-end="1109">Logging:</strong> <code data-start="1110" data-end="1121">log_lines</code> include request/response and the parsed <code data-start="1162" data-end="1181">requestIdentifier</code></p>
</li>
</ul>
<h3 data-start="1183" data-end="1212">🔒 Backward compatibility</h3>
<div class="_tableContainer_1rjym_1"><div tabindex="-1" class="group _tableWrapper_1rjym_13 flex w-fit flex-col-reverse">
Call | Behavior | requestIdentifier
-- | -- | --
check_vat_number(vat, country) | Uses checkVat SOAP Call | Not present (by design)
check_vat_number_with_request_identifier(vat, country, requester_country_code, requester_vat_number) | Uses checkVatApprox SOAP Call | Present (if VIES returns it)

</div></div>
<h3 data-start="1597" data-end="1609">🧭 Usage</h3>
<pre class="overflow-visible!" data-start="1671" data-end="2165"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-python"><span><span></span><span>import pyvat</span>

res = pyvat.check_vat_number_with_request_identifier(
    vat_number=</span><span><span class="hljs-string">"7770003038"</span></span><span>,
    country_code=</span><span><span class="hljs-string">"PL"</span></span><span>,
    requester_country_code=</span><span><span class="hljs-string">"DK"</span></span><span>,   </span><span><span class="hljs-comment"># your Member State</span></span><span>
    requester_vat_number=</span><span><span class="hljs-string">"43083341"</span></span><span>  </span><span><span class="hljs-comment"># number only, no country prefix</span></span><span>
)

</span><span><span class="hljs-built_in">print</span></span><span>(res.is_valid)             </span><span><span class="hljs-comment"># True/False</span></span><span>
</span><span><span class="hljs-built_in">print</span></span><span>(res.request_identifier)   </span><span><span class="hljs-comment"># e.g. "WAPIAAAAZnnAjXKl"</span></span><span>
</span><span><span class="hljs-built_in">print</span></span><span>(res.business_name)        </span><span><span class="hljs-comment"># from traderName</span></span><span>
</span><span><span class="hljs-built_in">print</span></span><span>(res.business_address)     </span><span><span class="hljs-comment"># from traderAddress</span></span><span>
</span></span></code></div></div></pre>

<h3 data-start="2178" data-end="2190">🧪 Tests</h3>
<ul class="contains-task-list" data-start="2191" data-end="2396">
<li class="task-list-item" data-start="2191" data-end="2396">
<p data-start="2197" data-end="2242"><input disabled="" type="checkbox" checked=""> Canned <code data-start="2204" data-end="2228">checkVatApproxResponse</code> XML verifies:</p>
<ul data-start="2245" data-end="2396">
<li data-start="2245" data-end="2265">
<p data-start="2247" data-end="2265"><code data-start="2247" data-end="2265">is_valid == True</code></p>
</li>
<li data-start="2268" data-end="2301">
<p data-start="2270" data-end="2301"><code data-start="2270" data-end="2301">business_country_code == "PL"</code></p>
</li>
<li data-start="2304" data-end="2349">
<p data-start="2306" data-end="2349"><code data-start="2306" data-end="2321">business_name</code> / <code data-start="2324" data-end="2342">business_address</code> parsed</p>
</li>
<li data-start="2352" data-end="2396">
<p data-start="2354" data-end="2396"><code data-start="2354" data-end="2396">request_identifier == "WAPIAAAAZnnAjXKl"</code></p>
</li>
</ul>
</li>
</ul>

DEVELOPER COMMENTS

Check if a VAT number is valid using a registry that supports request identification.

This function validates the given VAT number, taking into account the requester's information (requester_country_code and requester_vat_number) as required by certain national authorities for proper auditing and evidence. When called, the function will attempt to verify the VAT number and will return a VatNumberCheckResult instance containing the result of the validation. The result object also contains a 'verificationIdentifier' (request_identifier), which serves as a unique proof of the verification that can be stored and presented to authorities should a selling company undergo an audit.

    :param vat_number: VAT number to validate.
    :param requester_country_code: Country code of the requesting party (e.g., your own company).
    :param requester_vat_number: VAT number of the requesting party (e.g., your own company VAT number).
    :param country_code:
        Optional country code. Should be supplied if known, as there is no
        guarantee that naively entered VAT numbers contain the correct alpha-2
        country code prefix for EU countries just as not all non-EU countries
        have a reliable country code prefix. Default ``None`` prompting
        detection.
    :returns:
        a :class:`VatNumberCheckResult` instance containing the result for the
        full VAT number check. The result includes a 'verificationIdentifier' that can be retained
        for compliance and audit purposes with relevant authorities.
